### PR TITLE
Removed default "Loading..." text

### DIFF
--- a/src/windows/SpinnerDialogProxy.js
+++ b/src/windows/SpinnerDialogProxy.js
@@ -10,13 +10,13 @@ cordova.commandProxy.add("SpinnerDialog", {
       typeof Windows.UI !== 'undefined' /* Check that we have a UI to work with */ &&
       typeof Windows.UI.ViewManagement.StatusBar !== 'undefined' /* Check that we have the StatusBar to work with*/) {
 
-      var data = data[0] || { title: undefined };
+      
       progressIndicator = Windows.UI.ViewManagement.StatusBar.ProgressIndicator
         || Windows.UI.ViewManagement.StatusBar.getForCurrentView().progressIndicator;
 
-      if (data.title == null)
-        data.title = undefined;
-      progressIndicator.text = typeof data.title !== 'undefined' ? data.title : 'Loading...';
+      if (typeof(data[0]) !== 'undefined' && data[0] !== null) {
+        progressIndicator.text = data[0];
+	    }
       progressIndicator.showAsync();
       Windows.UI.ViewManagement.StatusBar.getForCurrentView().showAsync();
     } else if (typeof Windows !== 'undefined' &&


### PR DESCRIPTION
Only show custom status text when it has been specifically provided by parameter, otherwhise don't show any text whatsoever. Passing null now prevents any text from appearing.