### PR TITLE
Updated SpinnerDialog.js

### DIFF
--- a/www/SpinnerDialog.js
+++ b/www/SpinnerDialog.js
@@ -15,7 +15,7 @@ module.exports = {
     }
     cordova.exec(cancelCallback, null, 'SpinnerDialog', 'show', params);
   },
-  hide: function (success, fail) {
-    cordova.exec(success, fail, 'SpinnerDialog', 'hide', ["", ""]);
+  hide: function (wpStatusbar, success, fail) {
+    cordova.exec(success, fail, 'SpinnerDialog', 'hide', [wpStatusbar]);
   }
 };


### PR DESCRIPTION
Added wpStatusbar param to pass with SpinnerDialog.hide(true) to keep Windows Phone status bar visible.