### PR TITLE
Update SpinnerDialogProxy.js

### DIFF
--- a/src/windows/SpinnerDialogProxy.js
+++ b/src/windows/SpinnerDialogProxy.js
@@ -30,7 +30,11 @@ cordova.commandProxy.add("SpinnerDialog", {
       typeof Windows.UI !== 'undefined' /* Check that we have a UI to work with */ &&
       typeof Windows.UI.ViewManagement.StatusBar !== 'undefined' /* Check that we have the StatusBar to work with*/) {
 
-      progressIndicator.hideAsync();
+      try {
+        progressIndicator.hideAsync();
+      } catch(e) {
+        console.warn(e.message);
+      }
       /* Hide status bar if data is undefined or false exclusively */
       if(typeof(data[0]) === 'undefined' || data[0] === false) {
         Windows.UI.ViewManagement.StatusBar.getForCurrentView().hideAsync();


### PR DESCRIPTION
Fix to prevent startup error:
`Exception calling native with command :: SpinnerDialog :: hide ::exception=TypeError: Unable to get property 'hideAsync' of undefined or null reference`
on Windows Phone 8.1 devices with UWP.